### PR TITLE
fix: add minimum value for isAnimating to trigger on remotePlayer

### DIFF
--- a/src/core/RemotePlayerRenderer.ts
+++ b/src/core/RemotePlayerRenderer.ts
@@ -52,6 +52,7 @@ export class RemotePlayerRenderer {
     private networking: Networking;
     private localPlayer: Player;
     private deltaTime: number = 0; // Initialize deltaTime to avoid Deno error
+    private static minVelocityToAnimate = 0.1;
 
     private crosshairVec = new THREE.Vector2();
 
@@ -144,7 +145,7 @@ export class RemotePlayerRenderer {
         const playerId = remotePlayerData.id;
         const prevVelocity = this.previousVelocity[playerId] || 0;
 
-        if (prevVelocity === 0 && velocity > 0) {
+        if (prevVelocity <= RemotePlayerRenderer.minVelocityToAnimate && velocity > RemotePlayerRenderer.minVelocityToAnimate) {
             this.isAnimating[playerId] = true;
             this.animationPhase[playerId] = 0;
         }
@@ -200,7 +201,7 @@ export class RemotePlayerRenderer {
             playerObject.position.y += yOffset;
             this.lastRunningYOffset[playerId] = yOffset;
 
-            if (velocity === 0 && Math.cos(this.animationPhase[playerId]) <= 0) {
+            if (velocity <= RemotePlayerRenderer.minVelocityToAnimate && Math.cos(this.animationPhase[playerId]) <= 0) {
                 this.isAnimating[playerId] = false;
                 this.lastRunningYOffset[playerId] = 0;
             }


### PR DESCRIPTION
Should prevent remote players from doing the run animation when moving at a low velocity e.g. sliding down a slight angle