### PR TITLE
fix: let user use default name in chat

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -11331,7 +11331,6 @@
         "npm:@types/three@0.169",
         "npm:autoprefixer@^10.4.14",
         "npm:dot-prop@9",
-        "npm:express@^4.21.1",
         "npm:fdir@^6.4.2",
         "npm:front-matter@^4.0.2",
         "npm:joi@^17.13.3",

--- a/src/client/core/Networking.ts
+++ b/src/client/core/Networking.ts
@@ -159,6 +159,7 @@ export class Networking {
 		this.messagesBeingTyped = [];
 		for (const remotePlayer of this.remotePlayers) {
 			if (remotePlayer.id === this.localPlayer.id) {
+				if (this.localPlayer.name.length === 0) this.localPlayer.name = remotePlayer.name;
 				if (remotePlayer.forced) {
 					this.localPlayer.position.set(remotePlayer.position.x, remotePlayer.position.y, remotePlayer.position.z);
 					this.localPlayer.velocity.set(remotePlayer.velocity.x, remotePlayer.velocity.y, remotePlayer.velocity.z);
@@ -168,7 +169,7 @@ export class Networking {
 						remotePlayer.lookQuaternion.z,
 						remotePlayer.lookQuaternion.w,
 					);
-					//this.localPlayer.name = remotePlayer.name;
+					this.localPlayer.name = remotePlayer.name;
 					this.localPlayer.gravity = remotePlayer.gravity;
 					this.localPlayer.forcedAcknowledged = true;
 				} else {

--- a/src/client/ui/ChatOverlay.ts
+++ b/src/client/ui/ChatOverlay.ts
@@ -853,17 +853,18 @@ export class ChatOverlay {
 		}
 
 		if (e.key.toLowerCase() === 't' && !this.nameSettingActive) {
-			if (this.localPlayer.name.length > 0) this.localPlayer.chatActive = true;
-			else this.nameSettingActive = true;
+			//if (this.localPlayer.name.length > 0)
+			this.localPlayer.chatActive = true;
+			//else this.nameSettingActive = true;
 		}
 
 		if (e.key === '/' && !this.nameSettingActive && !this.localPlayer.chatActive) {
-			if (this.localPlayer.name.length > 0) {
-				this.localPlayer.chatActive = true;
-				this.localPlayer.chatMsg = '/';
-			} else {
-				this.nameSettingActive = true;
-			}
+			//if (this.localPlayer.name.length > 0) {
+			this.localPlayer.chatActive = true;
+			this.localPlayer.chatMsg = '/';
+			//} else {
+			//	this.nameSettingActive = true;
+			//}
 		}
 
 		if (e.key.toLowerCase() === 'n' && !this.localPlayer.chatActive) {


### PR DESCRIPTION
let someone send chat messages with the default username (possum000)
people tend to accidentally enter their intended chat message as their username