### PR TITLE
fix: don't force shots to hold for entire tick on local

### DIFF
--- a/src/client/core/Inventory.ts
+++ b/src/client/core/Inventory.ts
@@ -128,7 +128,7 @@ export class Inventory {
 
 		// Use spectated player's states if available, otherwise use local states
 		const rightClickHeld = spectatedPlayer ? spectatedPlayer.rightClickHeld : this.inputHandler.getAim();
-		const shooting = spectatedPlayer ? spectatedPlayer.shooting : isShootActive;
+		const shooting = spectatedPlayer ? spectatedPlayer.shooting : this.inputHandler.getShoot();
 		const heldItemInput = new HeldItemInput(shooting, rightClickHeld, false);
 
 		let downPressed = (this.inputHandler.getKey('[') || this.inputHandler.getInventoryIterationTouched()) &&


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/f5fb4b7b-d1fc-46b1-92a6-7637fd194127)
