### PR TITLE
Fix peer discovery startup and retries

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git
+.github
+.idea
+.nx
+.run
+
+node_modules
+dist
+
+.env
+.DS_Store
+servers.txt
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -186,23 +186,9 @@ export class GameServer {
 			}
 		});
 
-		this.router.get('/(.*)', async (context) => {
-			try {
-				await send(context, context.params[0], {
-					root: `${import.meta.dirname}/../../dist`,
-					index: 'index.html',
-				});
-			} catch {
-				try {
-					await send(context, 'index.html', {
-						root: `${import.meta.dirname}/../../dist`,
-					});
-				} catch (err) {
-					console.error('Error serving files:', err);
-					context.response.status = 500;
-					context.response.body = 'Internal Server Error';
-				}
-			}
+		this.router.get('/api/servers', (context) => {
+			context.response.type = 'application/json';
+			context.response.body = this.peerManager.peers;
 		});
 
 		this.router.get('/api/healthcheck', (context) => {
@@ -225,6 +211,25 @@ export class GameServer {
 			}
 		});
 
+		this.router.get('/(.*)', async (context) => {
+			try {
+				await send(context, context.params[0], {
+					root: `${import.meta.dirname}/../../dist`,
+					index: 'index.html',
+				});
+			} catch {
+				try {
+					await send(context, 'index.html', {
+						root: `${import.meta.dirname}/../../dist`,
+					});
+				} catch (err) {
+					console.error('Error serving files:', err);
+					context.response.status = 500;
+					context.response.body = 'Internal Server Error';
+				}
+			}
+		});
+
 		this.app.use(this.router.routes());
 		this.app.use(this.router.allowedMethods());
 	}
@@ -243,6 +248,9 @@ export class GameServer {
 			await serve(handler, {
 				port: config.server.port,
 				hostname: config.server.hostname,
+				onListen: () => {
+					this.peerManager.start();
+				},
 			});
 		} catch (error) {
 			console.error('Failed to start server:', error);

--- a/src/server/managers/PeerManager.test.ts
+++ b/src/server/managers/PeerManager.test.ts
@@ -1,0 +1,139 @@
+Deno.test('PeerManager starts after healthcheck and discovers configured peers', async () => {
+	const originalCwd = Deno.cwd();
+	const originalEnv = Deno.env.toObject();
+	const tempDir = await Deno.makeTempDir();
+	const selfPort = getOpenPort();
+	const peerPort = getOpenPort();
+	const selfUrl = `http://127.0.0.1:${selfPort}`;
+	const peerUrl = `http://127.0.0.1:${peerPort}`;
+	const selfAbort = new AbortController();
+	const peerAbort = new AbortController();
+
+	try {
+		Deno.chdir(tempDir);
+		Deno.env.set('SERVER_URL', selfUrl);
+		Deno.env.set('SERVER_NAME', 'self-test');
+		Deno.env.set('SERVER_DEFAULT_MAP', 'crackhouse_1');
+		Deno.env.set('GAME_MODE', 'bridge');
+		Deno.env.set('PEER_HEALTHCHECK_RETRIES', '1');
+		Deno.env.set('PEER_HEALTHCHECK_INTERVAL', '0');
+		Deno.env.set('PEER_UPDATE_TICK_INTERVAL', '1');
+		Deno.env.set('PEER_STALE_THRESHOLD', '1');
+
+		const { PeerManager } = await import('./PeerManager.ts');
+		const manager = new PeerManager({ serversFilePath: `${tempDir}/servers.txt` });
+		let peerInfoRequests = 0;
+		await Deno.writeTextFile(`${tempDir}/servers.txt`, `${peerUrl}/\n${selfUrl}/\nnot-a-url\n`);
+
+		const selfServer = Deno.serve(
+			{
+				hostname: '127.0.0.1',
+				port: selfPort,
+				signal: selfAbort.signal,
+				onListen: () => undefined,
+			},
+			(request) => {
+				const url = new URL(request.url);
+				if (
+					url.pathname === '/api/healthcheck' &&
+					request.headers.get('X-Health-Secret') === manager.healthSecret
+				) {
+					return new Response(null, { status: 200 });
+				}
+
+				return new Response(null, { status: 404 });
+			},
+		);
+
+		const peerServer = Deno.serve(
+			{
+				hostname: '127.0.0.1',
+				port: peerPort,
+				signal: peerAbort.signal,
+				onListen: () => undefined,
+			},
+			(request) => {
+				const url = new URL(request.url);
+				if (url.pathname !== '/api/getInfo') {
+					return new Response(null, { status: 404 });
+				}
+
+				peerInfoRequests++;
+				if (peerInfoRequests === 1) {
+					return new Response(null, { status: 503 });
+				}
+
+				return Response.json({
+					name: 'peer-test',
+					maxPlayers: 20,
+					currentPlayers: 0,
+					mapName: 'crackhouse_1',
+					tickRate: 24,
+					version: 'test',
+					gameMode: 'ffa',
+					playerMaxHealth: 100,
+					skyColor: '#000000',
+					tickComputeTime: 0,
+					cleanupComputeTime: 0,
+					url: peerUrl,
+					memUsageRss: 0,
+					memUsageHeapUsed: 0,
+					memUsageHeapTotal: 0,
+					memUsageExternal: 0,
+					idleKickTime: 600,
+					durabilityEnabled: false,
+				});
+			},
+		);
+
+		try {
+			await manager.start();
+			await waitFor(() => manager.peers.some((peer) => peer.url === peerUrl && peer.serverInfo?.name === 'peer-test'));
+
+			if (manager.peers.length !== 1) {
+				throw new Error(`Expected one discovered peer, got ${manager.peers.length}`);
+			}
+			if (peerInfoRequests < 2) {
+				throw new Error(`Expected peer info to be retried, got ${peerInfoRequests} request`);
+			}
+		} finally {
+			manager.shutdown();
+			selfAbort.abort();
+			peerAbort.abort();
+			await Promise.allSettled([selfServer.finished, peerServer.finished]);
+		}
+	} finally {
+		Deno.chdir(originalCwd);
+		restoreEnv(originalEnv);
+		await Deno.remove(tempDir, { recursive: true });
+	}
+});
+
+function getOpenPort() {
+	const listener = Deno.listen({ hostname: '127.0.0.1', port: 0 });
+	const port = (listener.addr as Deno.NetAddr).port;
+	listener.close();
+	return port;
+}
+
+async function waitFor(predicate: () => boolean) {
+	const deadline = Date.now() + 3000;
+	while (Date.now() < deadline) {
+		if (predicate()) return;
+		await new Promise((resolve) => setTimeout(resolve, 25));
+	}
+
+	throw new Error('Timed out waiting for condition');
+}
+
+function restoreEnv(originalEnv: Record<string, string>) {
+	for (const key of Object.keys(Deno.env.toObject())) {
+		if (!(key in originalEnv)) {
+			Deno.env.delete(key);
+		}
+	}
+
+	for (const [key, value] of Object.entries(originalEnv)) {
+		Deno.env.set(key, value);
+	}
+}

--- a/src/server/managers/PeerManager.ts
+++ b/src/server/managers/PeerManager.ts
@@ -10,18 +10,32 @@ const HEADER_HEALTH_SECRET = 'X-Health-Secret';
 const HEADER_CONTENT_TYPE = 'Content-Type';
 const CONTENT_TYPE_JSON = 'application/json';
 
+interface PeerManagerOptions {
+	serversFilePath?: string;
+}
+
 export class PeerManager {
 	peers: Peer[] = [];
 	private updateQueue: string[] = [];
 	private shareQueue: string[] = [];
+	private failedUrlAttempts: Map<string, number> = new Map();
+	private failedUrlRetryAfter: Map<string, number> = new Map();
 	healthSecret: string;
 	private serversFilePath = './servers.txt';
 	private isOperational = false; // Flag to indicate if the manager is running
 	private updateTimer: number | undefined = undefined; // Timer ID for setTimeout
+	private startPromise: Promise<void> | undefined = undefined;
 
-	constructor() {
+	constructor(options: PeerManagerOptions = {}) {
 		this.healthSecret = crypto.randomUUID();
-		this.initialize();
+		this.serversFilePath = options.serversFilePath ?? this.serversFilePath;
+	}
+
+	public start() {
+		if (!this.startPromise) {
+			this.startPromise = this.initialize();
+		}
+		return this.startPromise;
 	}
 
 	private async initialize() {
@@ -54,9 +68,11 @@ export class PeerManager {
 					headers: { [HEADER_HEALTH_SECRET]: this.healthSecret },
 				});
 				if (response.ok) {
+					await response.body?.cancel();
 					console.log('Initial healthcheck successful.');
 					return true; // Health check passed
 				} else {
+					await response.body?.cancel();
 					console.log(
 						`Healthcheck attempt ${i + 1} failed with status: ${response.status}`,
 					);
@@ -82,8 +98,8 @@ export class PeerManager {
 			const content = await Deno.readTextFile(this.serversFilePath);
 			const urls = content
 				.split('\n')
-				.map((url) => url.trim())
-				.filter((url) => url && url !== config.server.url); // Filter empty lines and self
+				.map((url) => this.normalizeUrl(url))
+				.filter((url): url is string => Boolean(url) && url !== this.selfUrl); // Filter empty lines and self
 			this.updateQueue = [...new Set(urls)]; // Ensure uniqueness
 			console.log(`Loaded ${this.updateQueue.length} initial peers from ${this.serversFilePath}`);
 		} catch (error) {
@@ -92,7 +108,7 @@ export class PeerManager {
 				const defaultUrl = 'https://candiru.xyz'; // Example default
 				try {
 					await Deno.writeTextFile(this.serversFilePath, `${defaultUrl}\n`);
-					if (defaultUrl !== config.server.url) {
+					if (defaultUrl !== this.selfUrl) {
 						this.updateQueue = [defaultUrl];
 					} else {
 						this.updateQueue = [];
@@ -100,7 +116,7 @@ export class PeerManager {
 				} catch (writeError) {
 					console.error(`Failed to create ${this.serversFilePath}:`, writeError);
 					// Still use the default URL even if file write fails
-					if (defaultUrl !== config.server.url) {
+					if (defaultUrl !== this.selfUrl) {
 						this.updateQueue = [defaultUrl];
 						console.log(`Using in-memory default peer: ${defaultUrl}`);
 					} else {
@@ -159,12 +175,19 @@ export class PeerManager {
 		if (!url) return; // Queue is empty
 
 		try {
+			const retryAfter = this.failedUrlRetryAfter.get(url);
+			if (retryAfter && Date.now() / 1000 < retryAfter) {
+				this.updateQueue.push(url);
+				return;
+			}
+
 			const peer = this.peers.find((p) => p.url === url);
 			const needsUpdate = !peer || (Date.now() / 1000 - peer.lastUpdate) > config.peer.staleThreshold;
 
 			if (needsUpdate) {
 				const response = await fetch(`${url}${API_GET_INFO}`);
 				if (!response.ok) {
+					await response.body?.cancel();
 					throw new Error(`Failed to fetch info from ${url}, status: ${response.status}`);
 				}
 				const data = await response.json();
@@ -181,6 +204,8 @@ export class PeerManager {
 					existingPeer.updateServerInfo(result.data);
 					// Reset failure count for the *peer* on success
 					existingPeer.failedAttempts = 0;
+					this.failedUrlAttempts.delete(url);
+					this.failedUrlRetryAfter.delete(url);
 				} else {
 					console.log(`Invalid data received from ${url}:`, result.error.issues);
 					this.handleFailedUpdate(url); // Treat invalid data as a failure
@@ -298,8 +323,20 @@ export class PeerManager {
 			// Removal of the peer happens in checkStalePeers based on this count.
 		} else {
 			// Failure occurred for a URL not currently in the active peers list.
-			// No separate tracking (urlFailureCounts removed). It might be retried if still in updateQueue.
-			console.log(`Update failed for URL ${url} (not an active peer).`);
+			const failedAttempts = (this.failedUrlAttempts.get(url) ?? 0) + 1;
+			this.failedUrlAttempts.set(url, failedAttempts);
+			this.failedUrlRetryAfter.set(url, Date.now() / 1000 + this.retryDelay(failedAttempts));
+
+			if (!this.updateQueue.includes(url)) {
+				this.updateQueue.push(url);
+				console.log(
+					`Update failed for URL ${url} (not an active peer). Retrying later, attempt ${failedAttempts}.`,
+				);
+			} else {
+				console.log(
+					`Update failed for URL ${url} (not an active peer). Attempt ${failedAttempts}.`,
+				);
+			}
 		}
 	}
 
@@ -309,7 +346,8 @@ export class PeerManager {
 	 * @param url The URL to add.
 	 */
 	private async addToServersFile(url: string) {
-		if (url === config.server.url) return; // Don't add self
+		const normalizedUrl = this.normalizeUrl(url);
+		if (!normalizedUrl || normalizedUrl === this.selfUrl) return; // Don't add self
 
 		try {
 			let content = '';
@@ -324,11 +362,11 @@ export class PeerManager {
 
 			const urls = content
 				.split('\n')
-				.map((u) => u.trim())
-				.filter((u) => u); // Get existing, trimmed, non-empty URLs
+				.map((u) => this.normalizeUrl(u))
+				.filter((u): u is string => Boolean(u)); // Get existing, trimmed, non-empty URLs
 
-			if (!urls.includes(url)) {
-				urls.push(url); // Add the new URL
+			if (!urls.includes(normalizedUrl)) {
+				urls.push(normalizedUrl); // Add the new URL
 
 				// Ensure the list doesn't exceed the maximum size
 				while (urls.length > config.peer.maxServers) {
@@ -340,11 +378,11 @@ export class PeerManager {
 				// Only write if content has actually changed
 				if (newContent !== content + (content.endsWith('\n') ? '' : '\n')) {
 					await Deno.writeTextFile(this.serversFilePath, newContent);
-					console.log(`Added ${url} to ${this.serversFilePath}`);
+					console.log(`Added ${normalizedUrl} to ${this.serversFilePath}`);
 				}
 			}
 		} catch (error) {
-			console.log(`Failed to add ${url} to ${this.serversFilePath}:`, error);
+			console.log(`Failed to add ${normalizedUrl} to ${this.serversFilePath}:`, error);
 		}
 	}
 
@@ -396,14 +434,13 @@ export class PeerManager {
 		console.log(`Received ${urls.length} server URLs.`);
 		let addedToQueue = 0;
 		urls.forEach((url) => {
-			// Basic validation
-			if (!url || typeof url !== 'string' || !url.startsWith('http')) {
+			const trimmedUrl = this.normalizeUrl(url);
+			if (!trimmedUrl) {
 				console.log(`Received invalid URL format: ${url}`);
 				return;
 			}
 
-			const trimmedUrl = url.trim();
-			if (trimmedUrl === config.server.url) return; // Ignore self
+			if (trimmedUrl === this.selfUrl) return; // Ignore self
 
 			// Check if it's already known (in peers list or update queue)
 			const isKnown = this.peers.some((p) => p.url === trimmedUrl) ||
@@ -418,6 +455,30 @@ export class PeerManager {
 		if (addedToQueue > 0) {
 			console.log(`Added ${addedToQueue} new unique URLs to the update queue.`);
 		}
+	}
+
+	private normalizeUrl(rawUrl: string) {
+		if (!rawUrl || typeof rawUrl !== 'string') return undefined;
+
+		try {
+			const url = new URL(rawUrl.trim());
+			if (url.protocol !== 'http:' && url.protocol !== 'https:') return undefined;
+			url.hash = '';
+			url.search = '';
+			url.pathname = url.pathname.replace(/\/+$/, '');
+			return url.toString().replace(/\/$/, '');
+		} catch {
+			return undefined;
+		}
+	}
+
+	private get selfUrl() {
+		return this.normalizeUrl(config.server.url);
+	}
+
+	private retryDelay(failedAttempts: number) {
+		const baseDelay = Math.max(config.peer.updateInterval, Math.min(config.peer.staleThreshold, 30));
+		return Math.min(baseDelay * failedAttempts, 60);
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Starts `PeerManager` only after the HTTP listener is active so the self-healthcheck can succeed.
- Keeps API peer routes ahead of the static catch-all and adds `/api/servers` for direct peer-list inspection.
- Normalizes peer URLs and retains unknown seed URLs with bounded retry/backoff so staggered server startup does not permanently drop peers.
- Adds a regression test for healthcheck startup plus retrying a temporarily failing seed peer.
- Adds `.dockerignore` so Docker builds do not stream `.git`, `node_modules`, local `.env`, or runtime peer files.

## Root Cause
Peer discovery was disabled at startup because `PeerManager` ran its self-healthcheck in the constructor before the server routes were registered or listening. When that failed, the manager stayed non-operational and never processed seed peers or incoming shared peer lists.

A second issue appeared during local multi-server testing: unknown seed URLs were dropped after failed initial fetches. If servers started in a staggered order, a peer could miss another server permanently until rediscovered through a different route.

## Validation
- `deno task allchecks`
- `deno test --allow-read --allow-write --allow-env --allow-net src/server/managers/PeerManager.test.ts`
- Ran three isolated local server instances on ports 3221, 3222, and 3223 with `ffa`, `ctf`, and `koth`; all converged to the other two peers through `/api/servers`.
- Stopped one local instance and confirmed the remaining two removed it from `/api/servers` after the configured failure window.

## Notes
Docker validation was attempted, but the initial build streamed a multi-GB context and the local OrbStack socket went away. This PR adds `.dockerignore` to prevent that context problem on subsequent builds.
