### PR TITLE
fix deno cache copy in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN --mount=type=cache,target=/tmp/deno-cache bash -c "set -euo pipefail \
   && /bin/deno task cache \
   && mkdir -p /deno-dir \
   && rm -rf /deno-dir/* \
-  && cp -a /tmp/deno-cache/. /deno-dir"
+  && tar --exclude='*-wal' --exclude='*-shm' -C /tmp/deno-cache -cf - . | tar -C /deno-dir -xf -"
 
 # Final runtime stage
 FROM debian:bookworm-slim


### PR DESCRIPTION
## What changed

- Replaced the Docker build-stage `cp -a /tmp/deno-cache/. /deno-dir` with a tar pipeline.
- Excluded Deno SQLite cache sidecar files matching `*-wal` and `*-shm` from the copied runtime cache.

## Why

Recent Coolify deployments failed nondeterministically when `cp -a` tried to copy transient Deno cache SQLite sidecar files after they disappeared:

```text
cp: cannot stat '/tmp/deno-cache/./dep_analysis_cache_v2-wal': No such file or directory
cp: cannot stat '/tmp/deno-cache/./dep_analysis_cache_v2-shm': No such file or directory
```

Those files are not required in the runtime image, so excluding them prevents the deployment from failing on a cache race.

## Validation

- `deno task allchecks`
- GitHub CI push checks will validate Docker build and container healthcheck.

Local Docker smoke testing could not run because the local Docker socket was unavailable.
