### PR TITLE
Fix stale spawn movement

### DIFF
--- a/src/client/core/Networking.test.ts
+++ b/src/client/core/Networking.test.ts
@@ -1,0 +1,44 @@
+import * as THREE from 'three';
+import { Player, type PlayerData } from '../../shared/Player.ts';
+import { Networking } from './Networking.ts';
+
+Deno.test('forced position update clears stale movement velocity', () => {
+	const localPlayer = new Player();
+	localPlayer.inputVelocity.set(0, -48, 0);
+	localPlayer.velocity.set(0, -48, 0);
+	localPlayer.gravity = -30;
+
+	const updateLocalPlayerState = (
+		Networking.prototype as unknown as {
+			updateLocalPlayerState(data: Partial<PlayerData>): void;
+		}
+	).updateLocalPlayerState;
+
+	updateLocalPlayerState.call(
+		{
+			localPlayer,
+			forcedZoomTriggered: false,
+		},
+		{
+			forced: true,
+			position: new THREE.Vector3(1, 0.5, 2),
+			velocity: new THREE.Vector3(0, 0, 0),
+			gravity: 0,
+		},
+	);
+
+	if (!localPlayer.position.equals(new THREE.Vector3(1, 0.5, 2))) {
+		throw new Error(`Expected forced position to be applied, got ${localPlayer.position.toArray().join(', ')}`);
+	}
+	if (!localPlayer.inputVelocity.equals(new THREE.Vector3(0, 0, 0))) {
+		throw new Error(
+			`Expected stale input velocity to be cleared, got ${localPlayer.inputVelocity.toArray().join(', ')}`,
+		);
+	}
+	if (localPlayer.gravity !== 0) {
+		throw new Error(`Expected gravity to be reset, got ${localPlayer.gravity}`);
+	}
+	if (!localPlayer.forcedAcknowledged) {
+		throw new Error('Expected forced update to be acknowledged');
+	}
+});

--- a/src/client/core/Networking.ts
+++ b/src/client/core/Networking.ts
@@ -181,6 +181,7 @@ export class Networking {
 			let funnyZoomFlag = false;
 			if (data.position) {
 				this.localPlayer.position.set(data.position.x, data.position.y, data.position.z);
+				this.localPlayer.inputVelocity.set(0, 0, 0);
 				funnyZoomFlag = true;
 			}
 			if (data.velocity) this.localPlayer.velocity.set(data.velocity.x, data.velocity.y, data.velocity.z);

--- a/src/server/managers/PlayerManager.test.ts
+++ b/src/server/managers/PlayerManager.test.ts
@@ -1,0 +1,40 @@
+import * as THREE from 'three';
+import { Player } from '../../shared/Player.ts';
+import { RespawnPoint } from '../models/RespawnPoint.ts';
+import { MapData } from '../models/MapData.ts';
+import { ItemManager } from './ItemManager.ts';
+import { PlayerManager } from './PlayerManager.ts';
+
+Deno.test('new player spawn clears movement inherited from pre-spawn client state', () => {
+	const manager = new PlayerManager(
+		new MapData('test', [
+			new RespawnPoint(new THREE.Vector3(1, 0.5, 2), new THREE.Quaternion(0, 0, 0, 1)),
+		], []),
+	);
+	manager.setItemManager({
+		triggerUpdateFlag() {},
+	} as unknown as ItemManager);
+
+	const player = new Player();
+	player.inputVelocity.set(0, -80, 0);
+	player.velocity.set(0, -80, 0);
+	player.gravity = -30;
+
+	const result = manager.addOrUpdatePlayer(player.toJSON());
+	if (!result.isNew) {
+		throw new Error('Expected player to be added');
+	}
+
+	if (!result.player.position.equals(new THREE.Vector3(1, 0.5, 2))) {
+		throw new Error(`Expected spawn position, got ${result.player.position.toArray().join(', ')}`);
+	}
+	if (!result.player.inputVelocity.equals(new THREE.Vector3(0, 0, 0))) {
+		throw new Error(`Expected input velocity reset, got ${result.player.inputVelocity.toArray().join(', ')}`);
+	}
+	if (!result.player.velocity.equals(new THREE.Vector3(0, 0, 0))) {
+		throw new Error(`Expected velocity reset, got ${result.player.velocity.toArray().join(', ')}`);
+	}
+	if (result.player.gravity !== 0) {
+		throw new Error(`Expected gravity reset, got ${result.player.gravity}`);
+	}
+});

--- a/src/server/managers/PlayerManager.ts
+++ b/src/server/managers/PlayerManager.ts
@@ -83,6 +83,7 @@ export class PlayerManager {
 			player.inventory = [...config.player.baseInventory];
 			const spawnPoint = this.getRandomSpawnPoint();
 			player.position = spawnPoint.vec;
+			this.resetMovementForSpawn(player);
 			player.health = config.player.maxHealth;
 			player.gameMsgs = [];
 			player.gameMsgs2 = [];
@@ -174,6 +175,7 @@ export class PlayerManager {
 
 		const spawnPoint = this.getRandomSpawnPoint();
 		player.position = spawnPoint.vec;
+		this.resetMovementForSpawn(player);
 		player.lookQuaternion = new THREE.Quaternion(
 			spawnPoint.quaternion.x,
 			spawnPoint.quaternion.y,
@@ -181,8 +183,6 @@ export class PlayerManager {
 			spawnPoint.quaternion.w,
 		);
 		player.health = config.player.maxHealth;
-		player.gravity = 0;
-		player.velocity = new THREE.Vector3(0, 0, 0);
 		player.forced = true;
 
 		const updatedPlayerData: PlayerWithExtras = {
@@ -251,6 +251,12 @@ export class PlayerManager {
 		const randomIndex = Math.floor(Math.random() * this.mapData.respawnPoints.length);
 		const respawnPoint = this.mapData.respawnPoints[randomIndex];
 		return { vec: respawnPoint.position, quaternion: respawnPoint.quaternion };
+	}
+
+	private resetMovementForSpawn(player: Player): void {
+		player.gravity = 0;
+		player.velocity = new THREE.Vector3(0, 0, 0);
+		player.inputVelocity = new THREE.Vector3(0, 0, 0);
 	}
 
 	public handleShotGroupAdded(playerId: number, heldItemIndex: number) {


### PR DESCRIPTION
## Summary

Fixes a first-load spawn race where a client could accept a forced spawn position while retaining stale downward `inputVelocity` from pre-spawn local physics.

## Root Cause

The server assigned the authoritative spawn position and reset `gravity`, but it did not clear the incoming client `inputVelocity` on new player spawn. The client also accepted forced position updates without clearing its locally integrated `inputVelocity`. On low spawn points, that stale downward movement could be applied immediately after the forced spawn and tunnel the player below thin ground.

## Changes

- Clear client `inputVelocity` whenever a forced position update is applied.
- Reset `gravity`, `velocity`, and `inputVelocity` together on server spawn/respawn.
- Add focused regression tests for client forced-position handling and server new-player spawn movement reset.

## Validation

- `/Users/isaacthoman/.deno/bin/deno test -A src/client/core/Networking.test.ts src/server/managers/PlayerManager.test.ts`
- `PATH="/Users/isaacthoman/.deno/bin:$PATH" deno task allchecks`